### PR TITLE
Redis-namespace could warn the user when an uknown command is issued

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -165,8 +165,13 @@ class Redis
     end
 
     def method_missing(command, *args, &block)
-      (before, after) = COMMANDS[command.to_s] ||
+      handling = COMMANDS[command.to_s] ||
         COMMANDS[ALIASES[command.to_s]]
+
+      warn("redis-namespace does not know how to handle '#{command}' command. " \
+      "Passing it to redis as is.") if handling.nil?
+      return if handling.nil?
+      (before, after) = handling
 
       # Add the namespace to any parameters that are keys.
       case before


### PR DESCRIPTION
Hello Chris,

We have got bitten a few times by using new redis commands with an old version of redis-namespace. With this patch the user gets a warning when the requested command is not included in the COMMANDS hash.
