### PR TITLE
Fixing blpop response

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -220,7 +220,7 @@ class Redis
       when :all
         result = rem_namespace(result)
       when :first
-        result[0] = rem_namespace(result[0])
+        result[0] = rem_namespace(result[0]) if result
       end
 
       result

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -42,6 +42,7 @@ describe "redis" do
     @namespaced.rpush "foo", "ns:string"
     @namespaced.blpop("foo", 1).should == ["foo", "string"]
     @namespaced.blpop("foo", 1).should == ["foo", "ns:string"]
+    @namespaced.blpop("foo", 1).should == nil
   end
 
   it "should be able to use a namespace with del" do


### PR DESCRIPTION
The return value from `blpop` contains the key name as the first element, as documented at http://redis.io/commands/blpop.

redis-namespace wasn't stripping the namespace from the key, have added a new return value "parsing option" called `:first` to just strip the namespace from the first element in the return value. And then applied that to the return value of `blpop`.
