### PR TITLE
use Redis.current as default Redis connection

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -160,7 +160,7 @@ class Redis
 
     def initialize(namespace, options = {})
       @namespace = namespace
-      @redis = options[:redis]
+      @redis = options[:redis] || Redis.current
     end
 
     # Ruby defines a now deprecated type method so we need to override it here


### PR DESCRIPTION
Any reason we don't use Redis.current as the default Redis connection? redis-rb has supported it since https://github.com/ezmobius/redis-rb/commit/23ed5974e96e89f4ef691139a9380a9d08e9cec6 . Would also dry up multiple Redis::Namespace.new calls pointing to the same default Redis connection. Can add a test for this if desired.
