### PR TITLE
Added support for mapped_hmget

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -87,6 +87,7 @@ class Redis
       "lset"             => [ :first ],
       "ltrim"            => [ :first ],
       "mapped_hmset"     => [ :first ],
+      "mapped_hmget"     => [ :first ],
       "mapped_mget"      => [ :all, :all ],
       "mget"             => [ :all ],
       "monitor"          => [ :monitor ],

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -96,6 +96,7 @@ describe "redis" do
     @namespaced.hkeys('foonx').should     == %w{ nx }
     @namespaced.hvals('foonx').should     == %w{ 10 }
     @namespaced.mapped_hmset('baz', {'key' => 'value', 'key1' => 'value1', 'a_number' => 4})
+    @namespaced.mapped_hmget('baz', 'key', 'key1', 'a_number').should == {'key' => 'value', 'key1' => 'value1', 'a_number' => '4'}
     @namespaced.hgetall('baz').should == {'key' => 'value', 'key1' => 'value1', 'a_number' => '4'}
   end
 


### PR DESCRIPTION
I noticed that a namespace was being applied to the top-level `mapped_hmset` key, but not to keys requested via `mapped_hmget`.  This is a patch to add a namespace to the top-level key of `mapped_hmget`.

Any alternate solutions or feedback are welcome – and thanks for Resque.
