### PR TITLE
add temporary namespace functionality

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -182,7 +182,7 @@ class Redis
               else {}
               end
 
-    attr_accessor :namespace
+    attr_writer :namespace
     attr_reader :redis
 
     def initialize(namespace, options = {})
@@ -208,6 +208,17 @@ class Redis
 
     def keys(query = nil)
       query.nil? ? super("*") : super
+    end
+
+    def namespace(desired_namespace = nil)
+      return @namespace if desired_namespace.nil?
+      begin
+        saved_namespace = @namespace
+        @namespace = desired_namespace
+        yield
+      ensure
+        @namespace = saved_namespace
+      end
     end
 
     def method_missing(command, *args, &block)

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -242,6 +242,21 @@ describe "redis" do
     @namespaced['foo'].should == 'chris'
   end
 
+  it "can accept a temporary namespace" do
+    @namespaced.namespace.should == :ns
+    @namespaced['foo'].should == nil
+
+    @namespaced.namespace(:spec) do
+      @namespaced.namespace.should == :spec
+      @namespaced['foo'].should == nil
+      @namespaced['foo'] = 'jake'
+      @namespaced['foo'].should == 'jake'
+    end
+
+    @namespaced.namespace.should == :ns
+    @namespaced['foo'].should == nil
+  end
+
   it "should respond to :namespace=" do
     @namespaced.respond_to?(:namespace=).should == true
   end


### PR DESCRIPTION
I find myself adding code all over the place that does essentially this, and I'm curious as to whether anyone else might find it useful.

my primary use case would be within Resque enqueueing jobs in the namespace they need to be in, but that doesn't make for a very pretty example. Taken from the specs, basically this allows you too:

``` ruby
@redis.namespace = :something

@redis.namespace(:'something.else') do
  @redis.namespace     # => :'something.else'
  @redis.set(:some_key, "some value")
end

@redis.namespace       #=> :something
```

which would set `:some_key` to `"some value"` in the `:'something.else'` namespace

as far as the specific implementation is concerned I'm open to any suggestions anyone might have.
