### PR TITLE
Make sure to namespace keys for EVAL/EVALSHA.

### DIFF
--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -246,7 +246,8 @@ describe "redis" do
     @namespaced.respond_to?(:namespace=).should == true
   end
 
-  if @redis_version >= Gem::Version.new("2.6.0")
+  # Redis 2.6 RC reports its version as 2.5.
+  if @redis_version >= Gem::Version.new("2.5.0")
     describe "redis 2.6 commands" do
       it "should namespace bitcount" do
         pending "awaiting implementaton of command in redis gem"
@@ -305,6 +306,36 @@ describe "redis" do
 
       it "should namespace restore" do
         pending "awaiting implementaton of command in redis gem"
+      end
+
+      it "should namespace eval keys passed in as array args" do
+        @namespaced.
+          eval("return {KEYS[1], KEYS[2]}", %w[k1 k2], %w[arg1 arg2]).
+          should == %w[ns:k1 ns:k2]
+      end
+
+      it "should namespace eval keys passed in as hash args" do
+        @namespaced.
+          eval("return {KEYS[1], KEYS[2]}", :keys => %w[k1 k2], :argv => %w[arg1 arg2]).
+          should == %w[ns:k1 ns:k2]
+      end
+
+      context '#evalsha' do
+        let!(:sha) do
+          @namespaced.script(:load, "return {KEYS[1], KEYS[2]}")
+        end
+
+        it "should namespace evalsha keys passed in as array args" do
+          @namespaced.
+            evalsha(sha, %w[k1 k2], %w[arg1 arg2]).
+            should == %w[ns:k1 ns:k2]
+        end
+
+        it "should namespace evalsha keys passed in as hash args" do
+          @namespaced.
+            evalsha(sha, :keys => %w[k1 k2], :argv => %w[arg1 arg2]).
+            should == %w[ns:k1 ns:k2]
+        end
       end
     end
   end


### PR DESCRIPTION
_I'd like to get this in ASAP, as this ties in with my work with @bvandenbos on making `resque-scheduler` more failure resistent. Thanks!_

---

The call semantics for both these methods are pretty specific, and require their own special case :(

Ex:

  # Both these are valid!
  redis.eval("return KEY[1]", %w[key1], %w[arg1 arg2])
  redis.eval("return KEY[1]", :keys => %w[key1], :argv => %w[arg1 arg2])

Any keys passed to Lua need to retain the correct namespace, which this pull request addresses.
