### PR TITLE
When using blpop/brpop with only one parameter, the :exclude_last option in the COMMANDS table excludes the list_name from being prefixed

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -233,7 +233,7 @@ class Redis
         args = add_namespace(args)
         args.unshift(first) if first
       when :exclude_last
-        last = args.pop
+        last = args.pop unless args.length == 1
         args = add_namespace(args)
         args.push(last) if last
       when :exclude_options

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -42,8 +42,10 @@ describe "redis" do
   it "should be able to use a namespace with bpop" do
     @namespaced.rpush "foo", "string"
     @namespaced.rpush "foo", "ns:string"
+    @namespaced.rpush "foo", "string_no_timeout"
     @namespaced.blpop("foo", 1).should == ["foo", "string"]
     @namespaced.blpop("foo", 1).should == ["foo", "ns:string"]
+    @namespaced.blpop("foo").should == ["foo", "string_no_timeout"]
     @namespaced.blpop("foo", 1).should == nil
   end
 


### PR DESCRIPTION
This code in the method_missing method excludes the last parameter of the called method

``` ruby
when :exclude_last
  last = args.pop
  args = add_namespace(args)
  args.push(last) if last
```

This doesn't take into account that for the blpop and brpop commands, the timeout parameter is optional.

This means there is only 1 parameter, which therefore won't be prefixed, even though it is the list_name, which does need to be prefixed.

Tests still pass and example added to test this case.
