### PR TITLE
Add warning against unknown commands

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -186,10 +186,12 @@ class Redis
 
     attr_writer :namespace
     attr_reader :redis
+    attr_accessor :warning
 
     def initialize(namespace, options = {})
       @namespace = namespace
       @redis = options[:redis] || Redis.current
+      @warning = options[:warning] || false
     end
 
     # Ruby defines a now deprecated type method so we need to override it here
@@ -236,8 +238,10 @@ class Redis
         COMMANDS[ALIASES[command.to_s]]
 
       # redis-namespace does not know how to handle this command.
-      # Passing it to @redis as is.
+      # Passing it to @redis as is, where redis-namespace shows
+      # a warning message if @warning is set.
       if handling.nil?
+        warn("Passing '#{command}' command to redis as is.") if @warning
         return @redis.send(command, *args, &block)
       end
 

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -292,6 +292,17 @@ describe "redis" do
     @namespaced.respond_to?(:namespace=).should == true
   end
 
+  it "should respond to :warning=" do
+    @namespaced.respond_to?(:warning=).should == true
+  end
+
+  it "should warn against unknown commands if :warning is true" do
+    @namespaced.warning = true
+    capture_stderr {
+      @namespaced.unknown('foo')
+    }.should == "Passing 'unknown' command to redis as is."
+  end
+
   # Redis 2.6 RC reports its version as 2.5.
   if @redis_version >= Gem::Version.new("2.5.0")
     describe "redis 2.6 commands" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,20 @@ $TESTING=true
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'redis/namespace'
 
+def capture_stderr
+  require 'stringio'
+  begin
+    original, $stderr = $stderr, StringIO.new
+    yield
+  rescue Redis::CommandError 
+    # ignore Redis::CommandError for test and
+    # return captured messages
+    $stderr.string.chomp
+  ensure
+    $stderr = original
+  end
+end
+
 RSpec::Matchers.define :have_key do |expected|
   match do |redis|
     redis.exists(expected)


### PR DESCRIPTION
Related to #34. This pull request adds a warning printed if redis-namespace does not know how to handle given commands. To avoid being annoying, the warning is optional and by default turned off. I would appreciate it if you could kindly review the code and merge it.
