### PR TITLE
make temporary namespace threadsafe

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -221,14 +221,12 @@ class Redis
     end
 
     def namespace(desired_namespace = nil)
-      return @namespace if desired_namespace.nil?
-      begin
-        saved_namespace = @namespace
-        @namespace = desired_namespace
-        yield
-      ensure
-        @namespace = saved_namespace
+      if desired_namespace
+        yield Redis::Namespace.new(desired_namespace,
+                                   :redis => @redis)
       end
+
+      @namespace
     end
 
     def method_missing(command, *args, &block)

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -277,11 +277,11 @@ describe "redis" do
     @namespaced.namespace.should == :ns
     @namespaced['foo'].should == nil
 
-    @namespaced.namespace(:spec) do
-      @namespaced.namespace.should == :spec
-      @namespaced['foo'].should == nil
-      @namespaced['foo'] = 'jake'
-      @namespaced['foo'].should == 'jake'
+    @namespaced.namespace(:spec) do |temp_ns|
+      temp_ns.namespace.should == :spec
+      temp_ns['foo'].should == nil
+      temp_ns['foo'] = 'jake'
+      temp_ns['foo'].should == 'jake'
     end
 
     @namespaced.namespace.should == :ns


### PR DESCRIPTION
replace my thread unsafe implementation of temporary namespacing with the one suggested by @yaauie  [here](https://github.com/defunkt/redis-namespace/pull/37#issuecomment-13631590) in #37
