### PR TITLE
Add `bundler/gem_tasks` tasks for easy building/releasing gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require "bundler/gem_tasks"
+
 task :default => :spec
 task :test    => :spec
 


### PR DESCRIPTION
`bundler/gem_tasks` provides convenient tasks for building/releasing gem.
The `release` task automatically creates git tag for recent version, so it prevents you forget to create git tag, refs #53.
