### PR TITLE
Remove warning about ambiguous first argument

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -346,7 +346,7 @@ class Redis
       when Hash
         Hash[*key.map {|k, v| [ rem_namespace(k), v ]}.flatten]
       else
-        key.to_s.gsub /^#{@namespace}:/, ""
+        key.to_s.gsub(/^#{@namespace}:/, "")
       end
     end
   end


### PR DESCRIPTION
I was pairing with @steveklabnik yesterday on Resque and saw that one of the warnings when running tests was in redis-namespace. This is a simple fix that removes the warning. I don't know how to really test it though.
