### PR TITLE
multi calls can now be made without a block.

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -220,7 +220,11 @@ class Redis
     end
 
     def multi(&block)
-      namespaced_block(:multi, &block)
+      if block_given?
+        namespaced_block(:multi, &block)
+      else
+        method_missing(:multi)
+      end
     end
 
     def pipelined(&block)

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -253,6 +253,17 @@ describe "redis" do
     @namespaced.hgetall("foo").should eq({"key1" => "value1"})
   end
 
+  it "should pass through multi commands without block" do
+    @namespaced.mapped_hmset "foo", {"key" => "value"}
+
+    @namespaced.multi
+    @namespaced.del "foo"
+    @namespaced.mapped_hmset "foo", {"key1" => "value1"}
+    @namespaced.exec
+
+    @namespaced.hgetall("foo").should eq({"key1" => "value1"})
+  end
+
   it "should add namespace to pipelined blocks" do
     @namespaced.mapped_hmset "foo", {"key" => "value"}
     @namespaced.pipelined do |r|


### PR DESCRIPTION
In the redis gem, a multi call made without a block simply calls the
command directly, leaving you to call exec yourself. This is now allowed
through Namespace.
