### PR TITLE
don't try to remove namespace from a redis future

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -312,6 +312,9 @@ class Redis
       # Dispatch the command to Redis and store the result.
       result = @redis.send(command, *args, &block)
 
+      # Don't try to remove namespace from a Redis::Future, you can't.
+      return result if result.is_a?(Redis::Future)
+
       # Remove the namespace from results that are keys.
       case after
       when :all

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -264,6 +264,13 @@ describe "redis" do
     @namespaced.hgetall("foo").should eq({"key1" => "value1"})
   end
 
+  it 'should return futures without attempting to remove namespaces' do
+    @namespaced.multi do
+      @future = @namespaced.keys('*')
+    end
+    @future.class.should be(Redis::Future)
+  end
+
   it "should add namespace to pipelined blocks" do
     @namespaced.mapped_hmset "foo", {"key" => "value"}
     @namespaced.pipelined do |r|


### PR DESCRIPTION
The commands `blpop`, `keys`, and `mapped_mget` all need the namespace to be removed after the command, but during a `multi` call, we get back `Redis::Future` objects, which will currently cause an error when we try to remove the namespace from it.

There are other ways to handle it, we could implement our own `Future` object as a wrapper around the `Redis` one that removes the namespace when `#value` gets called, but that'd be slightly more refactoring. I'm interested in doing it if anyone is interested in having it, but I thought I'd propose the simplest change first.
