### PR TITLE
Don't proxy `#eval` as it raises TypeError on nested namespaces

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -244,6 +244,10 @@ class Redis
       method_missing(:exec)
     end
 
+    def eval(*args)
+      method_missing(:eval, *args)
+    end
+
     def method_missing(command, *args, &block)
       handling = COMMANDS[command.to_s] ||
         COMMANDS[ALIASES[command.to_s]]

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -433,6 +433,21 @@ describe "redis" do
             should eq(%w[ns:k1 ns:k2])
         end
       end
+
+      context "in a nested namespace" do
+        let(:nested_namespace) { Redis::Namespace.new(:nest, :redis => @namespaced) }
+        let(:sha) { nested_namespace.script(:load, "return {KEYS[1], KEYS[2]}") }
+
+        it "should namespace eval keys passed in as hash args" do
+          nested_namespace.
+          eval("return {KEYS[1], KEYS[2]}", :keys => %w[k1 k2], :argv => %w[arg1 arg2]).
+          should eq(%w[ns:nest:k1 ns:nest:k2])
+        end
+        it "should namespace evalsha keys passed in as hash args" do
+          nested_namespace.evalsha(sha, :keys => %w[k1 k2], :argv => %w[arg1 arg2]).
+            should eq(%w[ns:nest:k1 ns:nest:k2])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Calling eval on a nested namespace causes a TypeError when proxied through method_missing. Added an eval method resolved the issue.  Also added a test to make sure evalsha worked as expected when in a nested namespace.  The example irb below demonstrates the error.

``` irb
irb(main):002:0> first_level = Redis::Namespace.new(:one)
=> #<Redis::Namespace:0x007fd1c9123c50 @redis=#<Redis client v3.0.4 for redis://127.0.0.1:6379/0>, @warning=false, @namespace=:one>
irb(main):003:0> first_level.eval("return {KEYS[1],KEYS[2]}", :keys => ['k1','k2'], :argv => ['a'])
=> ["one:k1", "one:k2"]
irb(main):004:0> second_level = Redis::Namespace.new(:two, :redis => first_level)
=> #<Redis::Namespace:0x007fd1c90db068 @redis=#<Redis::Namespace:0x007fd1c9123c50 @redis=#<Redis client v3.0.4 for redis://127.0.0.1:6379/0>, @warning=false, @namespace=:one>, @warning=false, @namespace=:two>
irb(main):005:0> second_level.eval("return {KEYS[1],KEYS[2]}", :keys => ['k1','k2'], :argv => ['a'])
TypeError: wrong argument type Hash (expected Binding)
    from /Users/rgraff/.rbenv/versions/1.9.3-p385-perf/lib/ruby/gems/1.9.1/gems/redis-namespace-1.3.1/lib/redis/namespace.rb:317:in `eval'
    from /Users/rgraff/.rbenv/versions/1.9.3-p385-perf/lib/ruby/gems/1.9.1/gems/redis-namespace-1.3.1/lib/redis/namespace.rb:317:in `method_missing'
    from (irb):5
    from /Users/rgraff/.rbenv/versions/1.9.3-p385-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.14/lib/rails/commands/console.rb:47:in `start'
    from /Users/rgraff/.rbenv/versions/1.9.3-p385-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.14/lib/rails/commands/console.rb:8:in `start'
    from /Users/rgraff/.rbenv/versions/1.9.3-p385-perf/lib/ruby/gems/1.9.1/gems/railties-3.2.14/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```
