### PR TITLE
Pin rspec to 2.99

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency    "redis", "~> 3.0.4"
 
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec", "~> 2.99"
 
   s.description = <<description
 Adds a Redis::Namespace class which can be used to namespace calls


### PR DESCRIPTION
Spec suite is broken on rspec 3.0.0
