### PR TITLE
Loosen redis dependency

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.files            += Dir.glob("spec/**/*")
 
-  s.add_dependency    "redis", "~> 3.0.4"
+  s.add_dependency    "redis", ">= 3.0.4", "< 4"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Redis 3.1 provides reconnect after fork support. All tests are still passing when rspec is locked to `2.x`. I didn't wanted to do this in this PR as you may have already other plans for it?
