### PR TITLE
Update redis dependency

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.files            += Dir.glob("spec/**/*")
 
-  s.add_dependency    "redis", "~> 3.0.4"
+  s.add_dependency    "redis", "~> 3.1.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Just updates the redis version dependency to ~> 3.1.0.

Not sure if there is anything more to do but the latest version of redis has some important bugfixes around reconnect on forking
