### PR TITLE
loosen dependency on redis-rb to allow v3.1.x

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.files            += Dir.glob("spec/**/*")
 
-  s.add_dependency    "redis", "~> 3.0.4"
+  s.add_dependency    "redis", "~> 3.0", ">= 3.0.4"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Since redis-rb is semver, loosen the dependency to allow users (but not require them) to use 3.1.x
