### PR TITLE
Fix zinterstore: change which params get namespaced

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -184,7 +184,7 @@ class Redis
       "zcard"            => [ :first ],
       "zcount"           => [ :first ],
       "zincrby"          => [ :first ],
-      "zinterstore"      => [ :first, :second ],
+      "zinterstore"      => [ :exclude_last ],
       "zrange"           => [ :first ],
       "zrangebyscore"    => [ :first ],
       "zrank"            => [ :first ],


### PR DESCRIPTION
This is using exclude options, which I don't believe is the correct option.

The params that you want to add namespacing to are the first (destination) and second (array of keys), not the third options param… which I don’t think even accepts keys?
