### PR TITLE
Add method to read the full namespace

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -291,6 +291,10 @@ class Redis
       @namespace
     end
 
+    def full_namespace
+      redis.is_a?(Namespace) ? "#{redis.full_namespace}:#{namespace}" : namespace.to_s
+    end
+
     def exec
       call_with_namespace(:exec)
     end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -790,4 +790,15 @@ describe "redis" do
       @redis.pfcount("ns:pfc").should == 10
     end
   end
+
+  describe :full_namespace do
+    it "should return the full namespace including sub namespaces" do
+      sub_namespaced     = Redis::Namespace.new(:sub1, :redis => @namespaced)
+      sub_sub_namespaced = Redis::Namespace.new(:sub2, :redis => sub_namespaced)
+
+      expect(@namespaced.full_namespace).to eql("ns")
+      expect(sub_namespaced.full_namespace).to eql("ns:sub1")
+      expect(sub_sub_namespaced.full_namespace).to eql("ns:sub1:sub2")
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a method which returns the fully qualified namespace name as a string.

Example:

```
redis = Redis.new

namespace = Redis::Namespace.new(:ns, redis: redis)
namespace.full_namespace # "ns"

namespace2 = Redis::Namespace.new(:sub, redis: namespace)
namespace2.full_namespace # "ns:sub"
```
