### PR TITLE
Added lock_for_update to namespaced commands

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -96,6 +96,7 @@ class Redis
       "lindex"           => [ :first ],
       "linsert"          => [ :first ],
       "llen"             => [ :first ],
+      "lock_for_update"  => [ :first ],
       "lpop"             => [ :first ],
       "lpush"            => [ :first ],
       "lpushx"           => [ :first ],


### PR DESCRIPTION
Using redis-lock gem I got lock_for_update deprecation warning.

```
Passing 'lock_for_update' command to redis as is; 
blind passthrough has been deprecated 
and will be removed in redis-namespace 2.0 ()
```

So I added this command to namespace.
