### PR TITLE
force key encoding to binary to avoid UTF-8 issues

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -488,7 +488,7 @@ class Redis
           key.each { |k| yielder.yield rem_namespace(k) }
         end
       else
-        key.to_s.sub(/\A#{@namespace}:/, '')
+        key.to_s.force_encoding("BINARY").sub(/\A#{@namespace}:/, '')
       end
     end
 


### PR DESCRIPTION
Somehow I ended up with keys in redis that contained invalid UTF-8 characters, which is now causing problems trying to retrieve them.

My code is currently failing with this stacktrace:

```
ArgumentError: invalid byte sequence in UTF-8
        from /var/geotrigger/api/vendor/bundle/ruby/2.0.0/gems/redis-namespace-1.3.2/lib/redis/namespace.rb:380:in `gsub'
        from /var/geotrigger/api/vendor/bundle/ruby/2.0.0/gems/redis-namespace-1.3.2/lib/redis/namespace.rb:380:in `rem_namespace'
        from /var/geotrigger/api/vendor/bundle/ruby/2.0.0/gems/redis-namespace-1.3.2/lib/redis/namespace.rb:376:in `block in rem_namespace'
        from /var/geotrigger/api/vendor/bundle/ruby/2.0.0/gems/redis-namespace-1.3.2/lib/redis/namespace.rb:376:in `map'
        from /var/geotrigger/api/vendor/bundle/ruby/2.0.0/gems/redis-namespace-1.3.2/lib/redis/namespace.rb:376:in `rem_namespace'
        from /var/geotrigger/api/vendor/bundle/ruby/2.0.0/gems/redis-namespace-1.3.2/lib/redis/namespace.rb:338:in `method_missing'
        from /var/geotrigger/api/vendor/bundle/ruby/2.0.0/gems/redis-namespace-1.3.2/lib/redis/namespace.rb:227:in `keys'
```

pointing to the source of the problem being the `.sub` method of the key name.

I was able to get around this issue by forcing the string encoding to binary, which still successfully removes the namespace prefix from the keys.