### PR TITLE
Make available for higher redis version.

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.files            += Dir.glob("spec/**/*")
 
-  s.add_dependency    "redis", "~> 3.0", ">= 3.0.4"
+  s.add_dependency    "redis", "~> 3.0", ">= 3.2.1"
 
   s.add_development_dependency "rake", "~> 10.1"
   s.add_development_dependency "rspec", "~> 2.14"


### PR DESCRIPTION
Hi, I need this functionality available for a higher version of redis. Since Redis Sentinel support is only available from version 3.2.x. Hope hear from you soon.