### PR TITLE
make brpoplpush work with the default 0 timeout or empty timeout options

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -59,7 +59,7 @@ class Redis
       "bitop"            => [ :exclude_first ],
       "blpop"            => [ :exclude_last, :first ],
       "brpop"            => [ :exclude_last, :first ],
-      "brpoplpush"       => [ :exclude_last ],
+      "brpoplpush"       => [ :first_two ],
       "debug"            => [ :exclude_first ],
       "decr"             => [ :first ],
       "decrby"           => [ :first ],
@@ -367,6 +367,9 @@ class Redis
       case before
       when :first
         args[0] = add_namespace(args[0]) if args[0]
+      when :first_two
+        args[0] = add_namespace(args[0]) if args[0]
+        args[1] = add_namespace(args[1]) if args[1]
       when :all
         args = add_namespace(args)
       when :exclude_first

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -84,6 +84,13 @@ describe "redis" do
     @namespaced.lrange('bar',0,-1).should eq(['bar'])
   end
 
+  it 'should be able to use a namespace with brpoplpush with default timeout' do
+    @namespaced.lpush('foo','bar')
+    @namespaced.brpoplpush('foo','bar').should eq('bar')
+    @namespaced.lrange('foo',0,-1).should eq([])
+    @namespaced.lrange('bar',0,-1).should eq(['bar'])
+  end
+
   it 'should be able to use a namespace with getbit' do
     @namespaced.set('foo','bar')
     @namespaced.getbit('foo',1).should eq(1)


### PR DESCRIPTION
The existing code doesn't properly namespace the keys if you don't specify a timeout explicitly