### PR TITLE
Add connected? to HELPER_COMMANDS

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -194,6 +194,7 @@ class Redis
       "echo"             => [],
       "ping"             => [],
       "disconnect!"      => [],
+      "connected?"       => [],
     }
     ADMINISTRATIVE_COMMANDS = {
       "bgrewriteaof"     => [],


### PR DESCRIPTION
As far as I'm aware, `connected?` is fully decoupled from namespace concerns, so it should be fine to pass this one through (without a deprecation warning). 
