### PR TITLE
Pass through the 'time' command

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -54,7 +54,7 @@ class Redis
     #     Add the namespace to all elements returned, e.g.
     #       key1 key2 => namespace:key1 namespace:key2
     NAMESPACED_COMMANDS = {
-      "append"           => [:first],
+      "append"           => [ :first ],
       "bitcount"         => [ :first ],
       "bitop"            => [ :exclude_first ],
       "blpop"            => [ :exclude_last, :first ],
@@ -191,9 +191,10 @@ class Redis
     }
     HELPER_COMMANDS = {
       "auth"             => [],
+      "disconnect!"      => [],
       "echo"             => [],
       "ping"             => [],
-      "disconnect!"      => [],
+      "time"             => [],
     }
     ADMINISTRATIVE_COMMANDS = {
       "bgrewriteaof"     => [],


### PR DESCRIPTION
As of https://github.com/resque/resque/pull/1480, Resque is using the `Redis#time` command to get the current server time. However, this creates noisy spam now if used in combination with Resque::Namespace, which doesn't pass the `time` command through (at least not without deprecation warning):

```
Passing 'time' command to redis as is; blind passthrough has been deprecated and will be removed in redis-namespace 2.0 (at /artifacts/ruby/2.2.0/bundler/gems/resque-3882cf0e73dc/lib/resque/data_store.rb:94:in `server_time')
```

@dylanahsmith @jpittis