### PR TITLE
Fix Travis: bump bundler and rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
   - jruby-18mode
   - jruby-19mode
-  - rbx-2.2.7
+  - rbx-2
 services:
   - redis


### PR DESCRIPTION
This should fix the (currently broken) CI run on Ruby 1.9.3 (see [here](https://travis-ci.org/resque/redis-namespace/jobs/150103076#L179) for an example). Don't ask why 😢 . See https://github.com/travis-ci/travis-ci/issues/3531.

@dylanahsmith 