### PR TITLE
Avoid modifying hash arguments during call to eval(sha)

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -365,8 +365,10 @@ class Redis
       (before, after) = handling
 
       # Avoid modifying the caller's arguments.
-      args = args.map do |arg|
-        if arg.is_a?(Hash)
+      args.map! do |arg|
+        if arg.is_a?(Array)
+          arg.dup
+        elsif arg.is_a?(Hash)
           arg.dup
         else
           arg # Some objects (e.g. symbol) can't be dup'd.
@@ -478,9 +480,10 @@ class Redis
 
       case key
       when Array
-        key.map {|k| add_namespace k}
+        key.map! {|k| add_namespace k}
       when Hash
-        Hash[*key.map {|k, v| [ add_namespace(k), v ]}.flatten]
+        key.keys.each {|k| key[add_namespace(k)] = key.delete(k)}
+        key
       else
         "#{@namespace}:#{key}"
       end

--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -364,6 +364,15 @@ class Redis
 
       (before, after) = handling
 
+      # Avoid modifying the caller's arguments.
+      args = args.map do |arg|
+        if arg.is_a?(Hash)
+          arg.dup
+        else
+          arg # Some objects (e.g. symbol) can't be dup'd.
+        end
+      end
+
       # Add the namespace to any parameters that are keys.
       case before
       when :first

--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -369,7 +369,7 @@ class Redis
         if arg.is_a?(Array)
           arg.map {|sub_arg| clone_args(sub_arg)}
         elsif arg.is_a?(Hash)
-          arg.map {|k, v| [clone_args(k), clone_args(v)]}.to_h
+          Hash[arg.map {|k, v| [clone_args(k), clone_args(v)]}]
         else
           arg # Some objects (e.g. symbol) can't be dup'd.
         end

--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -364,17 +364,6 @@ class Redis
 
       (before, after) = handling
 
-      # Avoid modifying the caller's (pass-by-reference) arguments.
-      def clone_args(arg)
-        if arg.is_a?(Array)
-          arg.map {|sub_arg| clone_args(sub_arg)}
-        elsif arg.is_a?(Hash)
-          Hash[arg.map {|k, v| [clone_args(k), clone_args(v)]}]
-        else
-          arg # Some objects (e.g. symbol) can't be dup'd.
-        end
-      end
-
       # Modify the local *args array in-place, no need to copy it.
       args.map! {|arg| clone_args(arg)}
 
@@ -462,6 +451,17 @@ class Redis
     end
 
   private
+
+    # Avoid modifying the caller's (pass-by-reference) arguments.
+    def clone_args(arg)
+      if arg.is_a?(Array)
+        arg.map {|sub_arg| clone_args(sub_arg)}
+      elsif arg.is_a?(Hash)
+        Hash[arg.map {|k, v| [clone_args(k), clone_args(v)]}]
+      else
+        arg # Some objects (e.g. symbol) can't be dup'd.
+      end
+    end
 
     def call_site
       caller.reject { |l| l.start_with?(__FILE__) }.first

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -485,6 +485,14 @@ describe "redis" do
           should eq(%w[ns:k1 ns:k2])
       end
 
+      it "should namespace eval keys passed in as hash args unmodified" do
+        args = { :keys => %w[k1 k2], :argv => %w[arg1 arg2] }
+        args.freeze
+        @namespaced.
+          eval("return {KEYS[1], KEYS[2]}", args).
+          should eq(%w[ns:k1 ns:k2])
+      end
+
       context '#evalsha' do
         let!(:sha) do
           @redis.script(:load, "return {KEYS[1], KEYS[2]}")
@@ -499,6 +507,14 @@ describe "redis" do
         it "should namespace evalsha keys passed in as hash args" do
           @namespaced.
             evalsha(sha, :keys => %w[k1 k2], :argv => %w[arg1 arg2]).
+            should eq(%w[ns:k1 ns:k2])
+        end
+
+        it "should namespace evalsha keys passed in as hash args unmodified" do
+          args = { :keys => %w[k1 k2], :argv => %w[arg1 arg2] }
+          args.freeze
+          @namespaced.
+            evalsha(sha, args).
             should eq(%w[ns:k1 ns:k2])
         end
       end


### PR DESCRIPTION
- The caller may not expect their arguments to be modified
- Modifying the hash arguments to namespace them can cause errors with redundant namespacing, for example when falling back to `eval` if a call to `evalsha` does not succeed when reusing the same argument object.

r: @fw42 @dylanahsmith 
cc: @fbogsany
