### PR TITLE
Adding example about get object without namespace into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ namespaced_redis.set('foo', 'bar') # redis_connection.set('ns:foo', 'bar')
 
 namespaced_redis.get('foo')
 # => "bar"
+redis_connection.get('foo')
+# => nil
 redis_connection.get('ns:foo')
 # => "bar"
 


### PR DESCRIPTION
```ruby
namespaced_redis.get('foo')
# => "bar"
redis_connection.get('foo') # Adding this example to explain how to namespace works
# => nil
redis_connection.get('ns:foo')
# => "bar"
```