### PR TITLE
support redis-rb 4.0.0

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -241,7 +241,7 @@ class Redis
       @deprecations = !!options.fetch(:deprecations) do
                         ENV['REDIS_NAMESPACE_DEPRECATIONS']
                       end
-      @is_client_respond = @redis.respond_to?(:_client)
+      @has_new_client_method = @redis.respond_to?(:_client)
     end
 
     def deprecations?
@@ -253,13 +253,13 @@ class Redis
     end
 
     def client
-      warn("The `client` method broken changed by redis-rb 4.0.0, so we should use `_client` method." +
-               "`client` method in redis-namespace will remove 2.0 (at #{call_site})") if @is_client_respond
+      warn("The client method is deprecated as of redis-rb 4.0.0, please use the new _client" +
+            "method instead. Support for the old method will be removed in redis-namespace 2.0.") if @has_new_client_method
       _client
     end
 
     def _client
-      @is_client_respond ? @redis._client : @redis.client # for redis-4.0.0
+      @has_new_client_method ? @redis._client : @redis.client # for redis-4.0.0
     end
 
     # Ruby defines a now deprecated type method so we need to override it here

--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -253,8 +253,8 @@ class Redis
     end
 
     def client
-      warn("The `client` method removed redis-rb 4.0.0, so use `_client` method." +
-               "`client` method will remove redis-namespace 2.0 (at #{call_site})") if @is_client_respond
+      warn("The `client` method broken changed by redis-rb 4.0.0, so we should use `_client` method." +
+               "`client` method in redis-namespace will remove 2.0 (at #{call_site})") if @is_client_respond
       _client
     end
 

--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -241,6 +241,7 @@ class Redis
       @deprecations = !!options.fetch(:deprecations) do
                         ENV['REDIS_NAMESPACE_DEPRECATIONS']
                       end
+      @is_client_respond = @redis.respond_to?(:_client)
     end
 
     def deprecations?
@@ -252,7 +253,13 @@ class Redis
     end
 
     def client
-      @redis.client
+      warn("The `client` method removed redis-rb 4.0.0, so use `_client` method." +
+               "`client` method will remove redis-namespace 2.0 (at #{call_site})") if @is_client_respond
+      _client
+    end
+
+    def _client
+      @is_client_respond ? @redis._client : @redis.client # for redis-4.0.0
     end
 
     # Ruby defines a now deprecated type method so we need to override it here

--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.files            += Dir.glob("spec/**/*")
 
-  s.add_dependency    "redis", "~> 3.0", ">= 3.0.4"
+  s.add_dependency    "redis", ">= 3.0.4"
 
   s.add_development_dependency "rake", "~> 10.1"
   s.add_development_dependency "rspec", "~> 2.14"

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -4,6 +4,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe "redis" do
   @redis_version = Gem::Version.new(Redis.current.info["redis_version"])
+  let(:redis_client) { @redis.respond_to?(:_client) ? @redis._client : @redis.client}
 
   before(:all) do
     # use database 15 for testing so we dont accidentally step on your real data
@@ -24,8 +25,12 @@ describe "redis" do
     @redis.quit
   end
 
-  it "proxies `client` to the client" do
-    @namespaced.client.should eq(@redis.client)
+  it "proxies `client` to the _client and deprecated" do
+    @namespaced.client.should eq(redis_client)
+  end
+
+  it "proxies `_client` to the _client" do
+    @namespaced._client.should eq(redis_client)
   end
 
   it "should be able to use a namespace" do


### PR DESCRIPTION
The redis-rb 4.0.0 remove [] and []= method alias.
So we must use get/set method.

And `client` method was broken changed.
https://github.com/redis/redis-rb/commit/31385074b6bbeef7e1f9849b0b1149b9ef870e2d

We must use the `_client` method for same behavier.
https://github.com/redis/redis-rb/commit/c239abb43c2dce99468bf94652a3c48b31a1041a

But if we remove `client` method, it's broken changes, so I alias `client` method to `_client`.
The user can be used redis-naespace 1.x with both redis-3.x and redis-4.x and can be gradually update.

