### PR TITLE
Support for UNLINK command (> Redis 4.0.0)

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -160,6 +160,7 @@ class Redis
       "sunionstore"      => [ :all ],
       "ttl"              => [ :first ],
       "type"             => [ :first ],
+      "unlink"           => [ :all   ],
       "unsubscribe"      => [ :all ],
       "zadd"             => [ :first ],
       "zcard"            => [ :first ],

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -75,6 +75,17 @@ describe "redis" do
     @namespaced.get('baz').should eq(nil)
   end
 
+  it "should be able to use a namespace with unlink" do
+    @namespaced.set('foo', 1000)
+    @namespaced.set('bar', 2000)
+    @namespaced.set('baz', 3000)
+    @namespaced.unlink 'foo'
+    @namespaced.get('foo').should eq(nil)
+    @namespaced.unlink 'bar', 'baz'
+    @namespaced.get('bar').should eq(nil)
+    @namespaced.get('baz').should eq(nil)
+  end
+
   it 'should be able to use a namespace with append' do
     @namespaced.set('foo', 'bar')
     @namespaced.append('foo','n').should eq(4)


### PR DESCRIPTION
Referencing Issue #148 

This adds support for the [UNLINK command](https://redis.io/commands/unlink) that is an alternative to DEL for background memory deallocation. 

Read about it [here](http://antirez.com/news/93).