### PR TITLE
Blind pass-thru connection command (redis 3.3.4+)

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -301,6 +301,10 @@ class Redis
       @namespace
     end
 
+    def connection
+      @redis.connection.tap { |info| info[:namespace] = @namespace }
+    end
+
     def exec
       call_with_namespace(:exec)
     end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -25,6 +25,12 @@ describe "redis" do
     @redis.quit
   end
 
+  # redis-rb 3.3.4+
+  it "should inject :namespace into connection info" do
+    info = @redis.connection.merge(:namespace => :ns)
+    expect(@namespaced.connection).to eq(info)
+  end
+
   it "proxies `client` to the _client and deprecated" do
     @namespaced.client.should eq(redis_client)
   end


### PR DESCRIPTION
And inject `:namespace` in results.

See: https://github.com/redis/redis-rb/blob/v3.3.4/lib/redis.rb#L2703-L2711
Resolves: #151