### PR TITLE
bugfix for Bundler 1.16.1 and rubygems 2.7.3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ cache: bundler
 services:
   - redis
 
+before_install:
+  - "travis_retry gem update --system"
+  - "travis_retry gem install bundler"
+
 script: bundle exec rake
 
 rvm:


### PR DESCRIPTION
When we use Bundler 1.16.1 and rubygems 2.7.3 on Travis environment, test will fail.
https://travis-ci.org/resque/redis-namespace/builds/362353925

So we need upgrade.

https://github.com/rubygems/rubygems/issues/2123