### PR TITLE
Use RSpec 3 instead RSpec2

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency    "redis", ">= 3.0.4"
 
   s.add_development_dependency "rake", "~> 10.1"
-  s.add_development_dependency "rspec", "~> 2.14"
+  s.add_development_dependency "rspec", "~> 3.7"
   s.add_development_dependency "rspec-its"
 
   s.description = <<description


### PR DESCRIPTION
Shall we use RSpec 3 instead of RSpec 2?
Maybe we can close this ticket https://github.com/resque/redis-namespace/pull/103 after this PR will be merged.
