### PR TITLE
Bump to 1.6.1

### DIFF
--- a/lib/redis/namespace/version.rb
+++ b/lib/redis/namespace/version.rb
@@ -2,6 +2,6 @@
 
 class Redis
   class Namespace
-    VERSION = '1.6.0'
+    VERSION = '1.6.1'
   end
 end


### PR DESCRIPTION
Includes https://github.com/resque/redis-namespace/compare/HEAD~8..master.

Notable PRs: 
- https://github.com/resque/redis-namespace/pull/155, https://github.com/resque/redis-namespace/pull/138 : rspec upgrade
- https://github.com/resque/redis-namespace/pull/152 : pass-thru for #connection
- https://github.com/resque/redis-namespace/pull/150 : unlink support

Any thoughts @rafaelfranca ?