### PR TITLE
Respect `deprecations?` regarding logging when using `client` method

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -259,7 +259,7 @@ class Redis
 
     def client
       warn("The client method is deprecated as of redis-rb 4.0.0, please use the new _client" +
-            "method instead. Support for the old method will be removed in redis-namespace 2.0.") if @has_new_client_method
+            "method instead. Support for the old method will be removed in redis-namespace 2.0.") if @has_new_client_method && deprecations?
       _client
     end
 


### PR DESCRIPTION
Currently this message gets printed even if `@deprecations` are set to false.