### PR TITLE
Add failing test for nonexistent Redis commands

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -183,9 +183,7 @@ class Redis
       "zscan"            => [ :first ],
       "zscan_each"       => [ :first ],
       "zscore"           => [ :first ],
-      "zunionstore"      => [ :exclude_options ],
-      "[]"               => [ :first ],
-      "[]="              => [ :first ]
+      "zunionstore"      => [ :exclude_options ]
     }
     TRANSACTION_COMMANDS = {
       "discard"          => [],


### PR DESCRIPTION
There are no `[]` and `[]=` commands in Redis, but redis-namespace responds to those methods. If you try to call one of them — Redis will fail with "Redis::CommandError: ERR unknown command '[]'" or "Redis::CommandError: ERR unknown command '[]'" depending of the command.