### PR TITLE
Add final namespace prefix to inspect

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -373,7 +373,7 @@ class Redis
 
     def inspect
       "<#{self.class.name} v#{VERSION} with client v#{Redis::VERSION} "\
-      "for #{@redis.id}/#{@namespace}>"
+      "for #{@redis.id}/#{full_namespace}>"
     end
 
     def respond_to_missing?(command, include_all=false)

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -442,6 +442,45 @@ describe "redis" do
     expect { @namespaced.unknown('foo') }.to raise_exception NoMethodError
   end
 
+  describe '#inspect' do
+    let(:single_level_names) { %i[first] }
+    let(:double_level_names) { %i[first second] }
+    let(:triple_level_names) { %i[first second third] }
+    let(:namespace_builder) do
+      ->(redis, *namespaces) { namespaces.reduce(redis) { |r, n| Redis::Namespace.new(n, redis: r) } }
+    end
+    let(:regexp_builder) do
+      ->(*namespaces) { %r{/#{namespaces.join(':')}>\z} }
+    end
+
+    context 'when one namespace' do
+      let(:single_namespaced) { namespace_builder.call(@redis, *single_level_names) }
+      let(:regexp) { regexp_builder.call(*single_level_names) }
+
+      it 'should have correct ending of inspect string' do
+        expect(regexp =~ single_namespaced.inspect).not_to be(nil)
+      end
+    end
+
+    context 'when two namespaces' do
+      let(:double_namespaced) { namespace_builder.call(@redis, *double_level_names) }
+      let(:regexp) { regexp_builder.call(*double_level_names) }
+
+      it 'should have correct ending of inspect string' do
+        expect(regexp =~ double_namespaced.inspect).not_to be(nil)
+      end
+    end
+
+    context 'when three namespaces' do
+      let(:triple_namespaced) { namespace_builder.call(@redis, *triple_level_names) }
+      let(:regexp) { regexp_builder.call(*triple_level_names) }
+
+      it 'should have correct ending of inspect string' do
+        expect(regexp =~ triple_namespaced.inspect).not_to be(nil)
+      end
+    end
+  end
+
   # Redis 2.6 RC reports its version as 2.5.
   if @redis_version >= Gem::Version.new("2.5.0")
     describe "redis 2.6 commands" do


### PR DESCRIPTION
Previously, if you have a nested redis inspect showed you only last
namespace, for example:

```ruby
parent = Redis::Namespace.new(:parent)
child = Redis::Namespace.new(:child, parent)
child.inspect # => <Redis::Namespace v1.6.0 with client v4.1.3 for redis://127.0.0.1:6379/0/child>
```

But now inspect shows full prefix, by which key will be stored in redis:

```ruby
child.inspect # => <Redis::Namespace v1.6.0 with client v4.1.3 for redis://127.0.0.1:6379/0/parent:child>
```

I think it would be better, if inspect returns full prefix instead of the only last namespace because it looks more natively and it's more useful, you inspect the object and you know the prefix of a stored key.
You don't need to keep in mind the parent of your namespaced redis instance.

I'm not sure about the delimiters of the prefix, I used `:`, but we can change it.
What do you think about it?