### PR TITLE
Remove deprecated has_rdoc config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
  - Add support for `BITPOS` command
+ - Remove deprecated has_rdoc config from gemspec
 
 ## 1.6.0
 

--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |s|
   s.homepage          = "http://github.com/resque/redis-namespace"
   s.email             = ["chris@ozmm.org", "hone02@gmail.com", "steve@steveklabnik.com", "me@yaauie.com"]
   s.authors           = ["Chris Wanstrath", "Terence Lee", "Steve Klabnik", "Ryan Biesemeyer"]
-  s.has_rdoc          = false
   s.license           = 'MIT'
 
   s.files             = %w( README.md Rakefile LICENSE )


### PR DESCRIPTION
Installing `redis-namespace` throws this warning due to the deprecated `has_rdoc` in the gemspec.
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/larouxn/.gem/ruby/2.6.5/bundler/gems/redis-namespace-aa6f7d627d4f/redis-namespace.gemspec:13.
```
<img width="1020" alt="Screen Shot 2019-10-18 at 14 35 14" src="https://user-images.githubusercontent.com/1557529/67119389-0ebaab80-f1b5-11e9-82ee-d3767957797d.png">

Let's remove `has_rdoc` to ensure we don't throw this warning.