### PR TITLE
Remove outdated rubies from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ before_install:
 script: bundle exec rake
 
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  - Add support for `BITPOS` command
  - Remove deprecated has_rdoc config from gemspec
  - Remove EOL rubies from travis.yml
+ - Add Ruby 2.4 minimum version to gemspec
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  - Add support for `BITPOS` command
  - Remove deprecated has_rdoc config from gemspec
+ - Remove EOL rubies from travis.yml
 
 ## 1.6.0
 

--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.files            += Dir.glob("spec/**/*")
 
+  s.required_ruby_version = '~> 2.4'
+
   s.add_dependency    "redis", ">= 3.0.4"
 
   s.add_development_dependency "rake", "~> 10.1"


### PR DESCRIPTION
Running well outdated rubies in Travis CI is breaking our test suite.
<img width="475" alt="Screen Shot 2019-10-18 at 14 51 14" src="https://user-images.githubusercontent.com/1557529/67121245-10866e00-f1b9-11e9-898a-5817fc2ac10c.png">
(screenshot is from the CI of https://github.com/resque/redis-namespace/pull/165)

Let's remove all EOL rubies and add a fresh Ruby 2.4 minimum version to the `gemspec`.