### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+
+## 1.7.0
+
  - Add support for `BITPOS` command
  - Remove deprecated has_rdoc config from gemspec
 

--- a/lib/redis/namespace/version.rb
+++ b/lib/redis/namespace/version.rb
@@ -2,6 +2,6 @@
 
 class Redis
   class Namespace
-    VERSION = '1.6.0'
+    VERSION = '1.7.0'
   end
 end


### PR DESCRIPTION
Prefer to merge https://github.com/resque/redis-namespace/pull/166 before this release.

With https://github.com/resque/redis-namespace/pull/166, our v1.7.0 changelog would look like so:

- Add support for `BITPOS` command
- Remove deprecated has_rdoc config from gemspec
- Remove EOL rubies from travis.yml
- Add Ruby 2.4 minimum version to gemspec

👋 @jeremy, note, CI will fail until https://github.com/resque/redis-namespace/pull/166 is merged.