### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version           = Redis::Namespace::VERSION
   s.date              = Time.now.strftime('%Y-%m-%d')
   s.summary           = "Namespaces Redis commands."
-  s.homepage          = "http://github.com/resque/redis-namespace"
+  s.homepage          = "https://github.com/resque/redis-namespace"
   s.email             = ["chris@ozmm.org", "hone02@gmail.com", "steve@steveklabnik.com", "me@yaauie.com"]
   s.authors           = ["Chris Wanstrath", "Terence Lee", "Steve Klabnik", "Ryan Biesemeyer"]
   s.license           = 'MIT'

--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -12,6 +12,13 @@ Gem::Specification.new do |s|
   s.authors           = ["Chris Wanstrath", "Terence Lee", "Steve Klabnik", "Ryan Biesemeyer"]
   s.license           = 'MIT'
 
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/resque/redis-namespace/issues",
+    "changelog_uri"     => "https://github.com/resque/redis-namespace/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/redis-namespace/#{s.version}",
+    "source_code_uri"   => "https://github.com/resque/redis-namespace/tree/v#{s.version}",
+  }
+
   s.files             = %w( README.md Rakefile LICENSE )
   s.files            += Dir.glob("lib/**/*")
   s.files            += Dir.glob("test/**/*")


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/redis-namespace), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.