### PR TITLE
Test against ruby 2.7 and fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
   - jruby-18mode
   - jruby-19mode

--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency    "redis", ">= 3.0.4"
 
-  s.add_development_dependency "rake", "~> 10.1"
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.7"
   s.add_development_dependency "rspec-its"
 

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -140,7 +140,7 @@ describe "redis" do
 
   it 'should be able to use a namespace with setbit' do
     @namespaced.setbit('virgin_key', 1, 1)
-    expect(@namespaced.exists('virgin_key')).to be true
+    expect(@namespaced.exists?('virgin_key')).to be true
     expect(@namespaced.get('virgin_key')).to eq(@namespaced.getrange('virgin_key',0,-1))
   end
 
@@ -239,7 +239,7 @@ describe "redis" do
     @namespaced.zadd('sort2', 2, 2)
     @namespaced.zadd('sort2', 3, 3)
     @namespaced.zadd('sort2', 4, 4)
-    @namespaced.zunionstore('union', ['sort1', 'sort2'], :weights => [2, 1])
+    @namespaced.zunionstore('union', ['sort1', 'sort2'], weights: [2, 1])
     expect(@namespaced.zrevrange('union', 0, -1)).to eq(%w( 2 4 3 1 ))
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,10 @@ $TESTING=true
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 require 'redis/namespace'
 
+if Redis.respond_to?(:exists_returns_integer=)
+  Redis.exists_returns_integer = true
+end
+
 module Helper
   def capture_stderr(io = nil)
     require 'stringio'


### PR DESCRIPTION
I just released redis `4.2.0` which replaced option hashes by true keyword arguments. 

So redis-namespace need to be updated otherwise it generates a lots of warnings with ruby 2.7.

@rafaelfranca 