### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("test/**/*")
   s.files            += Dir.glob("spec/**/*")
 
-  s.required_ruby_version = '~> 2.4'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_dependency    "redis", ">= 3.0.4"
 


### PR DESCRIPTION
Ruby master branch recently bumped the version number to 3.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

This is breaking our ruby-head CI.

cc @rafaelfranca 