### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ namespaced.redis.flushall()
 
 As mentioned above, 2.0 will remove blind passthrough and the administrative command passthrough.
 By default in 1.5+, deprecation warnings are present and enabled;
-they can be silenced by initializing `Redis::Namespace` with `warnings: false` or by setting the `REDIS_NAMESPACE_QUIET` environment variable.
+they can be silenced by initializing `Redis::Namespace` with `warning: false` or by setting the `REDIS_NAMESPACE_QUIET` environment variable.
 
 Early opt-in
 ------------


### PR DESCRIPTION
Warnings suppressed by the `:warning` key, not `:warnings` :)