### PR TITLE
Fix compatibility with redis-rb 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+- Fix compatibility with redis-rb 4.6.0. `Redis::Namespace#multi` and `Redis::Namespace#pipelined` were no longer
+  thread-safe. Calling these methods concurrently onthe same instance could cause pipelines or transaction to be
+  intertwined. See https://github.com/resque/redis-namespace/issues/191 and https://github.com/redis/redis-rb/issues/1088
+
 ## 1.8.1
 
  - Allow Ruby 3.0 version in gemspec

--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -492,6 +492,12 @@ class Redis
     end
     ruby2_keywords(:call_with_namespace) if respond_to?(:ruby2_keywords, true)
 
+  protected
+
+    def redis=(redis)
+      @redis = redis
+    end
+
   private
 
     if Hash.respond_to?(:ruby2_keywords_hash)
@@ -520,12 +526,13 @@ class Redis
     end
 
     def namespaced_block(command, &block)
-      redis.send(command) do |r|
-        begin
-          original, @redis = @redis, r
-          yield self
-        ensure
-          @redis = original
+      if block.arity == 0
+        redis.send(command, &block)
+      else
+        redis.send(command) do |r|
+          copy = dup
+          copy.redis = r
+          yield copy
         end
       end
     end


### PR DESCRIPTION
Fix: https://github.com/resque/redis-namespace/issues/191
Fix: https://github.com/redis/redis-rb/issues/1069
Fix: https://github.com/redis/redis-rb/issues/1088

In redis-rb 4.6.0, the object yielded by `multi` and `pipelined`
is an unsynchronized `PipelinedConnection` object.

This changed opened a thread safety issue in Redis::Namespace:

  - T1: `redis.multi do`, sets `Namespace#redis = PipelinedConnection`
  - T2: any command called before T1 exists the `multi` block is called on the pipelined connection

cc @ArturT, @sergio91pt (extra testing welcome)