### PR TITLE
Add ability to clear namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## x.y.z
 
+- Add ability to clear namespaces (#202). This operation can run for a very long time if the namespace contains
+  lots of keys! It should be used in tests, or when the namespace is small enough and you are sure you know what you are doing.
+
 ## 1.9.0
 
 - Accept Proc as a namespace (#203)

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -1048,4 +1048,30 @@ describe "redis" do
       expect(sub_sub_namespaced.full_namespace).to eql("ns:sub1:sub2")
     end
   end
+
+  describe :clear do
+    it "warns with helpful output" do
+      expect { @namespaced.clear }.to output(/can run for a very long time/).to_stderr
+    end
+
+    it "should delete all the keys" do
+      @redis.set("foo", "bar")
+      @namespaced.mset("foo1", "bar", "foo2", "bar")
+      capture_stderr { @namespaced.clear }
+
+      expect(@redis.keys).to eq ["foo"]
+      expect(@namespaced.keys).to be_empty
+    end
+
+    it "should delete all the keys in older redis" do
+      allow(@redis).to receive(:info).and_return({ "redis_version" => "2.7.0" })
+
+      @redis.set("foo", "bar")
+      @namespaced.mset("foo1", "bar", "foo2", "bar")
+      capture_stderr { @namespaced.clear }
+
+      expect(@redis.keys).to eq ["foo"]
+      expect(@namespaced.keys).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
There is often a need to clear the namespace and since there is no an implementation of this method, people usually bake their own implementations of clearing.

People also are/were believing that `flushall`/`flushdb` clears only the namespace (see #56). 

This PR uses [`scan`](https://redis.io/commands/scan/), but it is available only in redis >= 2.8.0, so it drops for iterating over all keys for older versions.