### PR TITLE
Allow Redis#close

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -202,6 +202,7 @@ class Redis
     HELPER_COMMANDS = {
       "auth"             => [],
       "disconnect!"      => [],
+      "close"            => [],
       "echo"             => [],
       "ping"             => [],
       "time"             => [],


### PR DESCRIPTION
It's been the recommended way to close the connection for a good decade, and it's the method used by the connection_pool gem.