### PR TITLE
Update brpoplpush to expect timeout as named argument

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 case redis_version = ENV.fetch('REDIS_VERSION', 'latest')
 when 'latest'
-  gem 'redis', '~> 4'
+  gem 'redis', '~> 5'
 else
   gem 'redis', "~> #{redis_version}"
 end

--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -60,7 +60,7 @@ class Redis
       "bitpos"           => [ :first ],
       "blpop"            => [ :exclude_last, :first ],
       "brpop"            => [ :exclude_last, :first ],
-      "brpoplpush"       => [ :exclude_last ],
+      "brpoplpush"       => [ :exclude_options ],
       "bzpopmin"         => [ :first ],
       "bzpopmax"         => [ :first ],
       "debug"            => [ :exclude_first ],

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -101,7 +101,7 @@ describe "redis" do
 
   it 'should be able to use a namespace with brpoplpush' do
     @namespaced.lpush('foo','bar')
-    expect(@namespaced.brpoplpush('foo','bar',0)).to eq('bar')
+    expect(@namespaced.brpoplpush('foo','bar', timeout: 0)).to eq('bar')
     expect(@namespaced.lrange('foo',0,-1)).to eq([])
     expect(@namespaced.lrange('bar',0,-1)).to eq(['bar'])
   end


### PR DESCRIPTION
Timeout as positional argument has been deprecated since 4.8.0

Not sure how version handling is usually implemented, we could probably detect the version of `redis` and expose a matching API if necessary.

Breaking change:
https://github.com/redis/redis-rb/pull/1129