### PR TITLE
Fix warning message 

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -137,7 +137,7 @@ class Redis
       "rpoplpush"        => [ :all ],
       "rpush"            => [ :first ],
       "rpushx"           => [ :first ],
-      "sadd"             => [ :first ],
+      "sadd?"             => [ :first ],
       "scard"            => [ :first ],
       "scan"             => [ :scan_style, :second ],
       "scan_each"        => [ :scan_style, :all ],


### PR DESCRIPTION
Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead.