### PR TITLE
Remove broken link to source code in gemspec

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
     "bug_tracker_uri"       => "https://github.com/resque/redis-namespace/issues",
     "changelog_uri"         => "https://github.com/resque/redis-namespace/blob/master/CHANGELOG.md",
     "documentation_uri"     => "https://www.rubydoc.info/gems/redis-namespace/#{s.version}",
-    "source_code_uri"       => "https://github.com/resque/redis-namespace/tree/v#{s.version}",
     "rubygems_mfa_required" => "true"
   }
 


### PR DESCRIPTION
The current link to “source code” on [Rubygems](https://rubygems.org/gems/redis-namespace) points to a broken link since there are no corresponding tagged version. We can remove the link since there is already a “homepage” link pointing to GitHub.