### PR TITLE
Add support for connection_pool gem

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.7"
   s.add_development_dependency "rspec-its"
+  s.add_development_dependency "connection_pool"
 
   s.description = <<description
 Adds a Redis::Namespace class which can be used to namespace calls

--- a/spec/deprecation_spec.rb
+++ b/spec/deprecation_spec.rb
@@ -31,7 +31,7 @@ describe Redis::Namespace do
     end
 
     before(:each) do
-      allow(redis).to receive(:unhandled) do |*args| 
+      allow(redis).to receive(:unhandled) do |*args|
         "unhandled(#{args.inspect})"
       end
       allow(redis).to receive(:flushdb).and_return("OK")

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -187,7 +187,12 @@ describe "redis" do
 
   it "should utilize connection_pool while using a namespace with mget" do
     memo = @namespaced
-    @namespaced = Redis::Namespace.new(:ns, redis: ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 })
+    connection_pool = ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 }
+    @namespaced = Redis::Namespace.new(:ns, redis: connection_pool)
+
+    expect(connection_pool).to receive(:with).and_call_original do |arg|
+      expect(arg).to be(an_instance_of(Redis))
+    end.at_least(:once)
 
     @namespaced.set('foo', 1000)
     @namespaced.set('bar', 2000)
@@ -392,7 +397,12 @@ describe "redis" do
 
   it "should utilize connection_pool while adding namepsace to multi blocks" do
     memo = @namespaced
-    @namespaced = Redis::Namespace.new(:ns, redis: ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 })
+    connection_pool = ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 }
+    @namespaced = Redis::Namespace.new(:ns, redis: connection_pool)
+
+    expect(connection_pool).to receive(:with).and_call_original do |arg|
+      expect(arg).to be(an_instance_of(Redis))
+    end.at_least(:once)
 
     @namespaced.mapped_hmset "foo", {"key" => "value"}
     @namespaced.multi do |r|
@@ -418,7 +428,12 @@ describe "redis" do
 
   it "should utilize connection_pool while passing through multi commands without block" do
     memo = @namespaced
-    @namespaced = Redis::Namespace.new(:ns, redis: ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 })
+    connection_pool = ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 }
+    @namespaced = Redis::Namespace.new(:ns, redis: connection_pool)
+
+    expect(connection_pool).to receive(:with).and_call_original do |arg|
+      expect(arg).to be(an_instance_of(Redis))
+    end.at_least(:once)
 
     @namespaced.mapped_hmset "foo", {"key" => "value"}
 
@@ -451,7 +466,12 @@ describe "redis" do
 
   it "should utilize connection_pool while adding namespace to pipelined blocks" do
     memo = @namespaced
-    @namespaced = Redis::Namespace.new(:ns, redis: ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 })
+    connection_pool = ConnectionPool.new(size: 2, timeout: 2) { Redis.new db: 15 }
+    @namespaced = Redis::Namespace.new(:ns, redis: connection_pool)
+
+    expect(connection_pool).to receive(:with).and_call_original do |arg|
+      expect(arg).to be(an_instance_of(Redis))
+    end.at_least(:once)
 
     @namespaced.mapped_hmset "foo", {"key" => "value"}
     @namespaced.pipelined do |r|


### PR DESCRIPTION
Adding support for @mperham's [connection_pool](https://github.com/mperham/connection_pool), in order to make gems compatible without the need to rely on method_missing that is used in [wrapper](https://github.com/mperham/connection_pool#migrating-to-a-connection-pool).

This PR was influenced by https://github.com/resque/redis-namespace/pull/135. Unfortunately we can't rely on `respond_to?(:with)` anymore, as this method was introduced to `redis-rb` gem [here](https://github.com/redis/redis-rb/commit/674541c5cc162b46066556811967a28a184f4665#), so we gotta check class name.  