### PR TITLE
Support for `bitfield` command

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -56,6 +56,7 @@ class Redis
     NAMESPACED_COMMANDS = {
       "append"           => [ :first ],
       "bitcount"         => [ :first ],
+      "bitfield"         => [ :first ],
       "bitop"            => [ :exclude_first ],
       "bitpos"           => [ :first ],
       "blpop"            => [ :exclude_last, :first ],

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -1061,6 +1061,13 @@ describe "redis" do
     end
   end
 
+  if @redis_version >= Gem::Version.new("3.2.0")
+    it 'should namespace bitfield' do
+      @namespaced.bitfield("bf", "SET", "i8", 0, "A".ord)
+      expect(@redis.get("ns:bf")).to eq("A")
+    end
+  end
+
   describe :full_namespace do
     it "should return the full namespace including sub namespaces" do
       sub_namespaced     = Redis::Namespace.new(:sub1, :redis => @namespaced)


### PR DESCRIPTION
This is the only missing command that prevents using redis-namespace with modern sidekiq