### PR TITLE
Add 3.2 to the list of Ruby CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - latest
         ruby-version:
           - head
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'


### PR DESCRIPTION
Adds 3.2 to the list of Ruby CI versions