### PR TITLE
Add LPOS command

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -104,6 +104,7 @@ class Redis
       "linsert"          => [ :first ],
       "llen"             => [ :first ],
       "lpop"             => [ :first ],
+      "lpos"             => [ :first ],
       "lpush"            => [ :first ],
       "lpushx"           => [ :first ],
       "lrange"           => [ :first ],

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -100,6 +100,12 @@ describe "redis" do
     expect(@redis.get('foo')).to eq('bar')
   end
 
+  it 'should be able to use a namespace with lpos' do
+    @namespaced.rpush('foo', %w[a b c 1 2 3 c c])
+    expect(@namespaced.lpos('foo', 'c')).to eq(2)
+    expect(@redis.lpos('mykey', 'c')).to be_nil
+  end
+
   it 'should be able to use a namespace with brpoplpush' do
     @namespaced.lpush('foo','bar')
     expect(@namespaced.brpoplpush('foo','bar',0)).to eq('bar')


### PR DESCRIPTION
Hello dear maintainer. 

The LPOS command was missing from the interface, I thought I should add it.

The test case uses the example provided in the official docs here: https://redis.io/commands/lpos/

Please let me know if I can be of any help.