### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/redis-namespace.gemspec
+++ b/redis-namespace.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
 
   s.files             = %w( README.md Rakefile LICENSE )
   s.files            += Dir.glob("lib/**/*")
-  s.files            += Dir.glob("test/**/*")
-  s.files            += Dir.glob("spec/**/*")
 
   s.required_ruby_version = '>= 2.4'
 


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

The specs (and tests) are omittable from the gem package because these are used only for the gem itself's local development, and would never be used by the users who install this gem.

With this patch, the gem package size shrinks as follows:
```
before: 19456 bytes
after:  12288 bytes
```