### PR TITLE
Add GETDEL command

### DIFF
--- a/lib/redis/namespace.rb
+++ b/lib/redis/namespace.rb
@@ -77,6 +77,7 @@ class Redis
       "eval"             => [ :eval_style ],
       "evalsha"          => [ :eval_style ],
       "get"              => [ :first ],
+      "getdel"           => [ :first ],
       "getex"            => [ :first ],
       "getbit"           => [ :first ],
       "getrange"         => [ :first ],

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -113,6 +113,12 @@ describe "redis" do
     expect(@namespaced.lrange('bar',0,-1)).to eq(['bar'])
   end
 
+  it "should be able to use a namespace with getdel" do
+    expect(@namespaced.set('mykey', 'Hello')).to eq('OK')
+    expect(@namespaced.getdel('mykey')).to eq('Hello')
+    expect(@namespaced.get('mykey')).to be_nil
+  end
+
   it "should be able to use a namespace with getex" do
     expect(@namespaced.set('mykey', 'Hello')).to eq('OK')
     expect(@namespaced.getex('mykey', ex: 50)).to eq('Hello')


### PR DESCRIPTION
Heya

Quick PR to add support for the GETDEL command: https://redis.io/docs/latest/commands/getdel/
I based this on other PRs that also added commands, and it's an easy one (single argument), so hopefully I didn't miss anything, but don't hesitate if you need to me to fix anything up.

Cheers!

Edit: The CI failed, looks like the release for jruby 9.2.21.0 only exists for ubuntu 22.04, but the CI is trying to pull a version for ubuntu 24.04, I think that means the ubuntu version used by the CI needs to target `ubuntu-22.04` instead of `ubuntu-latest`.